### PR TITLE
Remove @types/framer-motion as types are included in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.5.3",
+    "react-router-dom": "^6.20.0",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.3.2",
     "zustand": "^4.4.6"
@@ -32,7 +33,6 @@
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
-    "@types/framer-motion": "^10.16.5",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
- Remove unnecessary @types/framer-motion package
- Types are bundled with framer-motion package itself